### PR TITLE
Add 1.16 compatibility by literally changing one line of code

### DIFF
--- a/server_scripts/structure.js
+++ b/server_scripts/structure.js
@@ -56,11 +56,11 @@ function verifyStructure(block,pattern,key,direction) {
             } else { //array check id and blockstate
                 if (block.id == blockType[0]) {//check id
                     let validBlock = true //check for every key in the blockstate
-                    for(const key in blockType[1]) {
+                    Object.keys(blockType[1]).forEach(key => {
                         if(block.properties[key] == undefined || block.properties[key] != blockType[1][key].toString()) {
                             validBlock = false
                         }
-                    }
+                    })
                     if (validBlock) return
                 }
             }


### PR DESCRIPTION
Title. Should work for both 1.16 and 1.18 because it's standard JS syntax. 